### PR TITLE
rebuild-index using back up and restore strategy

### DIFF
--- a/update-index-schema-using-backup-restore-strategy-using-blobs/CONTRIBUTING.md
+++ b/update-index-schema-using-backup-restore-strategy-using-blobs/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to Azure Cognitive Search samples
+
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+ - [Code of Conduct](#coc)
+ - [Issues and Bugs](#issue)
+ - [Feature Requests](#feature)
+ - [Submission Guidelines](#submit)
+
+## <a name="coc"></a> Code of Conduct
+Help us keep this project open and inclusive. Please read and follow our [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+## <a name="issue"></a> Found an Issue?
+If you find a bug in the source code or a mistake in the documentation, you can help us by
+[submitting an issue](#submit-issue) to the GitHub Repository. Even better, you can
+[submit a Pull Request](#submit-pr) with a fix.
+
+## <a name="feature"></a> Want a Feature?
+You can *request* a new feature by [submitting an issue](#submit-issue) to the GitHub
+Repository. If you would like to *implement* a new feature, please submit an issue with
+a proposal for your work first, to be sure that we can use it.
+
+* **Small Features** can be crafted and directly [submitted as a Pull Request](#submit-pr).
+
+## <a name="submit"></a> Submission Guidelines
+
+### <a name="submit-issue"></a> Submitting an Issue
+Before you submit an issue, search the archive, maybe your question was already answered.
+
+If your issue appears to be a bug, and hasn't been reported, open a new issue.
+Help us to maximize the effort we can spend fixing issues and adding new
+features, by not reporting duplicate issues.  Providing the following information will increase the
+chances of your issue being dealt with quickly:
+
+* **Overview of the Issue** - if an error is being thrown a non-minified stack trace helps
+* **Version** - what version is affected (e.g. 0.1.2)
+* **Motivation for or Use Case** - explain what are you trying to do and why the current behavior is a bug for you
+* **Browsers and Operating System** - is this a problem with all browsers?
+* **Reproduce the Error** - provide a live example or a unambiguous set of steps
+* **Related Issues** - has a similar issue been reported before?
+* **Suggest a Fix** - if you can't fix the bug yourself, perhaps you can point to what might be
+  causing the problem (line of code or commit)
+
+You can file new issues by providing the above information at the corresponding repository's issues link: https://github.com/[organization-name]/[repository-name]/issues/new].
+
+### <a name="submit-pr"></a> Submitting a Pull Request (PR)
+Before you submit your Pull Request (PR) consider the following guidelines:
+
+* Search the repository (https://github.com/[organization-name]/[repository-name]/pulls) for an open or closed PR
+  that relates to your submission. You don't want to duplicate effort.
+
+* Make your changes in a new git fork:
+
+* Commit your changes using a descriptive commit message
+* Push your fork to GitHub:
+* In GitHub, create a pull request
+* If we suggest changes then:
+  * Make the required updates.
+  * Rebase your fork and force push to your GitHub repository (this will update your Pull Request):
+
+    ```shell
+    git rebase master -i
+    git push -f
+    ```
+
+That's it! Thank you for your contribution!

--- a/update-index-schema-using-backup-restore-strategy-using-blobs/LICENSE.md
+++ b/update-index-schema-using-backup-restore-strategy-using-blobs/LICENSE.md
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/update-index-schema-using-backup-restore-strategy-using-blobs/README.md
+++ b/update-index-schema-using-backup-restore-strategy-using-blobs/README.md
@@ -1,0 +1,73 @@
+---
+page_type: sample
+languages:
+  - csharp
+name: Update (Rebuild) an Azure Cognitive Search index schema using Back up and restore strategy using blob storage.
+description: "This application is written to update (rebuild) the schema of an Index as In all conditions we can not update the schema, it has to be rebuilt again to update in certain conditions. For more information - refer to https://docs.microsoft.com/en-us/azure/search/search-howto-reindex, It uses below strategy, first we need to attach the new(updated) schema of the index to this solution in NewSchema.schema file. First this application backs up a old (existing) index schema and its documents to Azure storage account, and then it deletes the old (exisitng) index, then this application uses attached NewSchema (if available in solution else uses the existing index schema from blob storage as a failover case, not to imapct the client for longer time) to recreate the index with updated schema. Depending on your needs, you can use all or part of this application to backup your index files. 
+For example, you may use the Basic or Free pricing tier to develop your index, and then want to move it to the Standard or higher tier for production use."
+products:
+  - azure
+  - azure-cognitive-search
+  - azure-storage
+urlFragment: azure-search-index-schema-update
+---
+
+# Update (Rebuild scenario) an Azure Cognitive Search index schema using Back up and restore strategy using blob storage
+
+![Flask sample MIT license badge](https://img.shields.io/badge/license-MIT-green.svg)
+
+This application rebuilds the index with the updated schema provided in NewSchema.schema, and in the process, It creates JSON files and uploads them(the index schema and documents) to blob storage. This tool is useful when you want to update your index schema and it requires to be rebuilt (as per the documentation https://docs.microsoft.com/en-us/azure/search/search-howto-reindex).
+
+## IMPORTANT - PLEASE READ
+Search indexes are different from other datastores because they are constantly ranking and scoring results and data may shift. If you page through search results or even use continuation tokens as this tool does, it is possible to miss some data during data extraction.
+
+As an example, assume that you are searching for documents and a document with ID 101 is part of page 5 of the search results. Then, as you are extracting data from page to page, and move from page 4 to page 5, it is possible that now ID 101 is actually part of page 4. This means that when you look at page 5, it is no longer there and you have missed that document.
+
+For this reason, this tool compares the number of index documents in the original index and the updated index. If the numbers don't match, the updated index may be missing data. Although this safeguard does not provide a perfect solution, it does help you help prevent you from missing data.
+
+Also, as an extra precaution, it is best if there are no changes being made to the search index when you use run this tool.
+
+**If your index has more than 100,000 documents**, this sample, as written, will not work. This is because the REST API $skip feature, that is used for paging, has a 100K document limit. However, you can work around this limitation by adding code to iterate over, and filter on, a facet with less that 100K documents per facet value.
+
+## Prerequisites
+
+- [Visual Studio](https://visualstudio.microsoft.com/downloads/)
+- [Azure Cognitive Search service](https://docs.microsoft.com/azure/search/search-create-service-portal)
+- [Azure storage account] (https://azure.microsoft.com/en-in/services/storage/blobs/)
+
+## This solution is leveraged from the exisitng sample: index-backup-restore (which uses local file storage) and this solution uses azure blob storage.
+
+## Setup
+
+1. Clone or download this sample repository.
+1. Extract contents if the download is a zip file. Make sure the files are read-write.
+
+This sample is available in below version:
+
++ **v11** uses the new [Azure.Search.Documents](https://docs.microsoft.com/dotnet/api/overview/azure/search.documents-readme) client library, highly recommended for all new projects
+
+## Run the sample
+
+[!NOTE] In this application there is a file "NewSchema.schema" which is the updated schema. Please update it with your latest schema which is the end result.
+
+1. Open the AzureSearchSchemaUpdate.sln project in Visual Studio.
+
+1. By default, this application will back up the exisitng schema and documents, then it will delete the exisitng Index and then use the NewSchem.schema to create the index. 
+    - If you only want to back up the index and not restore it immediately, do this:
+        - Comment out the code in the **Main** method after the **BackupIndexAndDocuments** method call.
+        - Comment out the last two lines of the **ConfigurationSetup** method that set the _TargetSearchClient_ and _TargetIndexClient_.
+    - If you want to restore a index that you previously backed up, do this:
+        - Make sure that the the _BackupDirectory_ in the appsettings.json file is pointing to to the backup location.
+        - Comment out the **BackupIndexAndDocuments** method call and the the line that checks the _targetCount_ in the **Main** method.
+        - Comment out the lines in **ConfigurationSetup** method that set the _SourceSearchClient_ and _SourceIndexClient_.
+
+1. Open the appsettings.json and replace the placeholder strings with all applicable values:
+
+    - The search service name (SearchServiceName) and key (AdminKey) and the name of the index (IndexName) that you want to update the schema.
+    - The connection string of stoage account (StorageConnectionString) and container name (BackupContainerName) where the schema and documents are backed-up/restored/copied from existing index.
+
+1. Compile and Run the project.
+
+## Next steps
+
+You can learn more about Azure Cognitive Search on the [official documentation site](https://docs.microsoft.com/azure/search).

--- a/update-index-schema-using-backup-restore-strategy-using-blobs/README.md
+++ b/update-index-schema-using-backup-restore-strategy-using-blobs/README.md
@@ -33,7 +33,7 @@ Also, as an extra precaution, it is best if there are no changes being made to t
 
 - [Visual Studio](https://visualstudio.microsoft.com/downloads/)
 - [Azure Cognitive Search service](https://docs.microsoft.com/azure/search/search-create-service-portal)
-- [Azure storage account] (https://azure.microsoft.com/en-in/services/storage/blobs/)
+- [Azure storage account](https://azure.microsoft.com/en-in/services/storage/blobs/)
 
 ## This solution is leveraged from the exisitng sample: index-backup-restore (which uses local file storage) and this solution uses azure blob storage.
 

--- a/update-index-schema-using-backup-restore-strategy-using-blobs/README.md
+++ b/update-index-schema-using-backup-restore-strategy-using-blobs/README.md
@@ -53,13 +53,6 @@ This sample is available in below version:
 1. Open the AzureSearchSchemaUpdate.sln project in Visual Studio.
 
 1. By default, this application will back up the exisitng schema and documents, then it will delete the exisitng Index and then use the NewSchem.schema to create the index. 
-    - If you only want to back up the index and not restore it immediately, do this:
-        - Comment out the code in the **Main** method after the **BackupIndexAndDocuments** method call.
-        - Comment out the last two lines of the **ConfigurationSetup** method that set the _TargetSearchClient_ and _TargetIndexClient_.
-    - If you want to restore a index that you previously backed up, do this:
-        - Make sure that the the _BackupDirectory_ in the appsettings.json file is pointing to to the backup location.
-        - Comment out the **BackupIndexAndDocuments** method call and the the line that checks the _targetCount_ in the **Main** method.
-        - Comment out the lines in **ConfigurationSetup** method that set the _SourceSearchClient_ and _SourceIndexClient_.
 
 1. Open the appsettings.json and replace the placeholder strings with all applicable values:
 

--- a/update-index-schema-using-backup-restore-strategy-using-blobs/v11/AzureSearchSchemaUpdate.sln
+++ b/update-index-schema-using-backup-restore-strategy-using-blobs/v11/AzureSearchSchemaUpdate.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.352
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureSearchSchemaUpdate", "AzureSearchSchemaUpdate\AzureSearchSchemaUpdate.csproj", "{3BA854A7-9DF4-4BE1-9749-E51A49AE2E16}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3BA854A7-9DF4-4BE1-9749-E51A49AE2E16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3BA854A7-9DF4-4BE1-9749-E51A49AE2E16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BA854A7-9DF4-4BE1-9749-E51A49AE2E16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3BA854A7-9DF4-4BE1-9749-E51A49AE2E16}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CB63787D-86CA-48E4-849F-371290479660}
+	EndGlobalSection
+EndGlobal

--- a/update-index-schema-using-backup-restore-strategy-using-blobs/v11/AzureSearchSchemaUpdate/AzureSearchHelper.cs
+++ b/update-index-schema-using-backup-restore-strategy-using-blobs/v11/AzureSearchSchemaUpdate/AzureSearchHelper.cs
@@ -1,0 +1,72 @@
+﻿//Copyright 2019 Microsoft
+
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+
+//       http://www.apache.org/licenses/LICENSE-2.0
+
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace AzureSearchSchemaUpdate
+{
+    public class AzureSearchHelper
+    {
+        public const string ApiVersionString = "api-version=2019-05-06";
+
+        private static readonly JsonSerializerOptions _jsonOptions;
+
+        static AzureSearchHelper()
+        {
+            _jsonOptions = new JsonSerializerOptions { };
+
+            _jsonOptions.Converters.Add(new JsonStringEnumConverter());
+        }
+
+        public static string SerializeJson(object value)
+        {
+            return JsonSerializer.Serialize(value, _jsonOptions);
+        }
+
+        public static T DeserializeJson<T>(string json)
+        {
+            return JsonSerializer.Deserialize<T>(json, _jsonOptions);
+        }
+
+        public static async Task<HttpResponseMessage> SendSearchRequestAsync(HttpClient client, HttpMethod method, Uri uri, string json = null)
+        {
+            UriBuilder builder = new UriBuilder(uri);
+            string separator = string.IsNullOrWhiteSpace(builder.Query) ? string.Empty : "&";
+            builder.Query = builder.Query.TrimStart('?') + separator + ApiVersionString;
+
+            var request = new HttpRequestMessage(method, builder.Uri);
+
+            if (json != null)
+            {
+                request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            }
+
+            return await client.SendAsync(request).ConfigureAwait(false) ;
+        }
+
+        public static async Task EnsureSuccessfulSearchResponseAsync(HttpResponseMessage response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                string error = response.Content == null ? null : await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                throw new Exception("Search request failed: " + error);
+            }
+        }
+    }
+}

--- a/update-index-schema-using-backup-restore-strategy-using-blobs/v11/AzureSearchSchemaUpdate/AzureSearchSchemaUpdate.csproj
+++ b/update-index-schema-using-backup-restore-strategy-using-blobs/v11/AzureSearchSchemaUpdate/AzureSearchSchemaUpdate.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Search.Documents" Version="11.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.20" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
+    <PackageReference Include="Microsoft.Spatial" Version="7.6.0" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="NewSchema.schema">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/update-index-schema-using-backup-restore-strategy-using-blobs/v11/AzureSearchSchemaUpdate/AzureStorageHelper.cs
+++ b/update-index-schema-using-backup-restore-strategy-using-blobs/v11/AzureSearchSchemaUpdate/AzureStorageHelper.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace AzureSearchSchemaUpdate
+{
+    public class AzureStorageHelper
+    {
+        private static string ContentType = "application/json";
+
+        // upload the file to blob storage.
+        public async static Task UploadAsync(string connectionString, string containerName, string fileName, byte[] fileData)
+        {
+            CloudBlobContainer cloudBlobContainer = await GetContainerAsync(connectionString, containerName).ConfigureAwait(false);
+            await cloudBlobContainer.SetPermissionsAsync(new BlobContainerPermissions { PublicAccess = BlobContainerPublicAccessType.Off }).ConfigureAwait(false);
+
+            if (!string.IsNullOrWhiteSpace(fileName) && fileData != null)
+            {
+                var cloudBlockBlob = cloudBlobContainer.GetBlockBlobReference(fileName);
+                cloudBlockBlob.Properties.ContentType = ContentType;
+                await cloudBlockBlob.UploadFromByteArrayAsync(fileData, 0, fileData.Length).ConfigureAwait(false);
+            }
+        }
+
+        // download content from blob storage.
+        public async static Task<string> DownloadAsync(string connectionString, string containerName, string fileName)
+        {
+            CloudBlobContainer cloudBlobContainer = await GetContainerAsync(connectionString, containerName).ConfigureAwait(false);
+            CloudBlockBlob cloudBlockBlob = cloudBlobContainer.GetBlockBlobReference(fileName);
+            return await cloudBlockBlob.DownloadTextAsync().ConfigureAwait(false);
+        }
+
+        // Get blob list based condition.
+        public async static Task<string[]> GetDocumentsListAsync(string connectionString, string containerName, string startsWith = "", string endsWith = ".json")
+        {
+            CloudBlobContainer cloudBlobContainer = await GetContainerAsync(connectionString, containerName).ConfigureAwait(false);
+            BlobContinuationToken continuationToken = null;
+            var blobResultSegment = await cloudBlobContainer.ListBlobsSegmentedAsync(continuationToken);
+            var blobs = blobResultSegment.Results.Select(i => i.Uri.Segments.Last()).Where(e => e.StartsWith(startsWith, StringComparison.OrdinalIgnoreCase) && e.EndsWith(endsWith, StringComparison.OrdinalIgnoreCase)).ToArray();
+
+            return blobs;
+        }
+
+        // Get Container object.
+        private static async Task<CloudBlobContainer> GetContainerAsync(string connectionString, string containerName)
+        {
+            var account = CloudStorageAccount.Parse(connectionString);
+            var cloudBlobClient = account.CreateCloudBlobClient();
+            var cloudBlobContainer = cloudBlobClient.GetContainerReference(containerName);
+            if (!await cloudBlobContainer.ExistsAsync().ConfigureAwait(false))
+            {
+                await cloudBlobContainer.CreateAsync().ConfigureAwait(false);
+            }
+
+            return cloudBlobContainer;
+        }
+    }
+}

--- a/update-index-schema-using-backup-restore-strategy-using-blobs/v11/AzureSearchSchemaUpdate/NewSchema.schema
+++ b/update-index-schema-using-backup-restore-strategy-using-blobs/v11/AzureSearchSchemaUpdate/NewSchema.schema
@@ -1,0 +1,21 @@
+﻿{
+  "@odata.context": "",
+  "@odata.etag": "",
+  "name": "",
+  "defaultScoringProfile": "",
+  "fields": [],
+  "scoringProfiles": [
+  ],
+  "corsOptions": null,
+  "suggesters": [
+  ],
+  "analyzers": [
+  ],
+  "tokenizers": [
+  ],
+  "tokenFilters": [
+  ],
+  "charFilters": [
+  ],
+  "encryptionKey": null
+}

--- a/update-index-schema-using-backup-restore-strategy-using-blobs/v11/AzureSearchSchemaUpdate/Program.cs
+++ b/update-index-schema-using-backup-restore-strategy-using-blobs/v11/AzureSearchSchemaUpdate/Program.cs
@@ -1,0 +1,324 @@
+﻿// This is a prototype tool that allows for extraction of data from a search index
+// Since this tool is still under development, it should not be used for production usage
+
+using Azure;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Indexes;
+using Azure.Search.Documents.Models;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AzureSearchSchemaUpdate
+{
+    class Program
+    {
+        private static string NewSchemaFile = "NewSchema.schema";
+        private static string SearchServiceName;
+        private static string AdminKey;
+        private static string IndexName;
+        private static string BackupContainer;
+        private static string StorageAccountConnectionString;
+
+        private static SearchIndexClient IndexClient;
+        private static SearchClient SearchClient;
+
+        private static int MaxBatchSize = 500;          // JSON files will contain this many documents / file and can be up to 1000
+        private static int ParallelizedJobs = 10;       // Output content in parallel jobs
+
+        static async Task Main(string[] args)
+        {
+
+            //Get search service info and index name from appsettings.json file
+            //Set up search service clients
+            ConfigurationSetup();
+
+            //Backup the old index
+            Console.WriteLine("\nSTART INDEX BACKUP");
+            int oldDocsCount = await BackupIndexAndDocumentsAsync().ConfigureAwait(false);
+
+            //Recreate and import content to updated index
+            Console.WriteLine("\nSTART INDEX RESTORE");
+            await DeleteIndexAsync().ConfigureAwait(false);
+            await CreateIndexAsync().ConfigureAwait(false);
+
+            // import docs from back up storage.
+            await ImportFromJSONAsync().ConfigureAwait(false);
+            Console.WriteLine("\r\n  Waiting 10 seconds for updated index content...");
+            Console.WriteLine("  NOTE: For really large indexes it may take longer to index all content.\r\n");
+            Thread.Sleep(10000);
+
+            // Validate all content is in updated index
+            int updatedCount = GetCurrentDocCount(SearchClient);
+            Console.WriteLine("\nSAFEGUARD CHECK: Old and updated index counts should match");
+            Console.WriteLine(" Old index contains {0} docs", oldDocsCount);
+            Console.WriteLine(" Updated index contains {0} docs\r\n", updatedCount);
+
+            Console.WriteLine("Press any key to continue...");
+            Console.ReadLine();
+        }
+
+        static void ConfigurationSetup()
+        {
+
+            IConfigurationBuilder builder = new ConfigurationBuilder().AddJsonFile("appsettings.json");
+            IConfigurationRoot configuration = builder.Build();
+
+            SearchServiceName = configuration["SearchServiceName"];
+            AdminKey = configuration["AdminKey"];
+            IndexName = configuration["IndexName"];
+            BackupContainer = configuration["BackupContainerName"];
+            StorageAccountConnectionString = configuration["StorageConnectionString"];
+
+            Console.WriteLine("CONFIGURATION:");
+            Console.WriteLine("\n  Search service and index {0}, {1}", SearchServiceName, IndexName);
+            Console.WriteLine("\n  Backup container: " + BackupContainer);
+
+            IndexClient = new SearchIndexClient(new Uri("https://" + SearchServiceName + ".search.windows.net"), new AzureKeyCredential(AdminKey));
+            SearchClient = IndexClient.GetSearchClient(IndexName);
+        }
+
+        static async Task<int> BackupIndexAndDocumentsAsync()
+        {
+            // Backup the index schema to the specified backup container
+            Console.WriteLine("\n  Backing up index schema to container: {0}\r\n", BackupContainer + "\\" + IndexName + ".schema");
+
+            await AzureStorageHelper.UploadAsync(StorageAccountConnectionString, BackupContainer, IndexName + ".schema", await GetIndexSchemaAsync().ConfigureAwait(false)).ConfigureAwait(false);
+
+            // Extract the content to JSON files 
+            int oldDocCount = GetCurrentDocCount(SearchClient);
+            WriteIndexDocuments(oldDocCount);     // Output content from index to json files
+            return oldDocCount;
+        }
+
+        static void WriteIndexDocuments(int CurrentDocCount)
+        {
+            // Write document files in batches (per MaxBatchSize) in parallel
+            string IDFieldName = GetIDFieldName();
+            int FileCounter = 0;
+            for (int batch = 0; batch <= (CurrentDocCount / MaxBatchSize); batch += ParallelizedJobs)
+            {
+
+                List<Task> tasks = new List<Task>();
+                for (int job = 0; job < ParallelizedJobs; job++)
+                {
+                    FileCounter++;
+                    int fileCounter = FileCounter;
+                    if ((fileCounter - 1) * MaxBatchSize < CurrentDocCount)
+                    {
+                        Console.WriteLine("  Backing up documents to {0} - (batch size = {1})", IndexName + fileCounter + ".json", MaxBatchSize);
+
+                        tasks.Add(Task.Factory.StartNew(() =>
+                            ExportToJSONAsync((fileCounter - 1) * MaxBatchSize, IDFieldName, IndexName + fileCounter + ".json")
+                        ));
+                    }
+
+                }
+                Task.WaitAll(tasks.ToArray());  // Wait for all the stored procs in the group to complete
+            }
+
+            return;
+        }
+
+        static async Task ExportToJSONAsync(int Skip, string IDFieldName, string FileName)
+        {
+            // Extract all the documents from the selected index to JSON files in batches of 500 docs / file
+            string json = string.Empty;
+            try
+            {
+                SearchOptions options = new SearchOptions()
+                {
+                    SearchMode = SearchMode.All,
+                    Size = MaxBatchSize,
+                    Skip = Skip
+                };
+
+                SearchResults<SearchDocument> response = SearchClient.Search<SearchDocument>("*", options);
+
+                foreach (var doc in response.GetResults())
+                {
+                    json += JsonSerializer.Serialize(doc.Document) + ",";
+                    json = json.Replace("\"Latitude\":", "\"type\": \"Point\", \"coordinates\": [");
+                    json = json.Replace("\"Longitude\":", "");
+                    json = json.Replace(",\"IsEmpty\":false,\"Z\":null,\"M\":null,\"CoordinateSystem\":{\"EpsgId\":4326,\"Id\":\"4326\",\"Name\":\"WGS84\"}", "]");
+                    json += "\r\n";
+                }
+
+                // Output the formatted content to a file
+                json = json.Substring(0, json.Length - 3); // remove trailing comma
+
+                json = "{\"value\": [" + json + "]}";
+                await AzureStorageHelper.UploadAsync(StorageAccountConnectionString, BackupContainer, FileName, System.Text.Encoding.ASCII.GetBytes(json)).ConfigureAwait(false);
+                Console.WriteLine("  Total documents: {0}", response.GetResults().Count().ToString());
+                json = string.Empty;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Error: {0}", ex.Message.ToString());
+            }
+        }
+
+        static string GetIDFieldName()
+        {
+            // Find the id field of this index
+            string IDFieldName = string.Empty;
+            try
+            {
+                var schema = IndexClient.GetIndex(IndexName);
+                foreach (var field in schema.Value.Fields)
+                {
+                    if (field.IsKey == true)
+                    {
+                        IDFieldName = Convert.ToString(field.Name);
+                        break;
+                    }
+                }
+
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Error: {0}", ex.Message.ToString());
+            }
+
+            return IDFieldName;
+        }
+
+        static async Task<byte[]> GetIndexSchemaAsync()
+        {
+
+            // Extract the schema for this index
+            // We use REST here because we can take the response as-is
+
+            Uri ServiceUri = new Uri("https://" + SearchServiceName + ".search.windows.net");
+            HttpClient HttpClient = new HttpClient();
+            HttpClient.DefaultRequestHeaders.Add("api-key", AdminKey);
+
+            byte[] Schema = null;
+            try
+            {
+                Uri uri = new Uri(ServiceUri, "/indexes/" + IndexName);
+                HttpResponseMessage response = await AzureSearchHelper.SendSearchRequestAsync(HttpClient, HttpMethod.Get, uri);
+                await AzureSearchHelper.EnsureSuccessfulSearchResponseAsync(response);
+                Schema = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Error: {0}", ex.Message.ToString());
+            }
+
+            return Schema;
+        }
+
+        private static async Task<bool> DeleteIndexAsync()
+        {
+            Console.WriteLine("\n  Delete the index {0} in {1} search service, if it exists", IndexName, SearchServiceName);
+            // Delete the index if it exists
+            try
+            {
+                await IndexClient.DeleteIndexAsync(IndexName).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("  Error deleting index: {0}\r\n", ex.Message);
+                Console.WriteLine("  Did you remember to set your SearchServiceName and SearchServiceApiKey?\r\n");
+                return false;
+            }
+
+            return true;
+        }
+
+        static async Task CreateIndexAsync()
+        {
+            Console.WriteLine("\n  Create index {0} in {1} search service", IndexName, SearchServiceName);
+            // Use the schema file to create an updated index.
+            // I like using REST here since I can just take the response as-is
+
+            if (File.Exists(NewSchemaFile))
+            {
+                // create using the new schema file.
+                await AzureStorageHelper.UploadAsync(StorageAccountConnectionString, BackupContainer, NewSchemaFile, await File.ReadAllBytesAsync(NewSchemaFile).ConfigureAwait(false)).ConfigureAwait(false);
+            }
+            else
+            {
+                // if new schema file is not present, as failover, we will create the index with old schema as is from blob storage.
+                NewSchemaFile = IndexName + ".schema";
+            }
+
+            string json = await AzureStorageHelper.DownloadAsync(StorageAccountConnectionString, BackupContainer, NewSchemaFile).ConfigureAwait(false);
+
+            // Do some cleaning of this file to change index name, etc
+            json = "{" + json.Substring(json.IndexOf("\"name\""));
+            int indexOfIndexName = json.IndexOf("\"", json.IndexOf("name\"") + 5) + 1;
+            int indexOfEndOfIndexName = json.IndexOf("\"", indexOfIndexName);
+            json = json.Substring(0, indexOfIndexName) + IndexName + json.Substring(indexOfEndOfIndexName);
+
+            Uri ServiceUri = new Uri("https://" + SearchServiceName + ".search.windows.net");
+            HttpClient HttpClient = new HttpClient();
+            HttpClient.DefaultRequestHeaders.Add("api-key", AdminKey);
+
+            try
+            {
+                Uri uri = new Uri(ServiceUri, "/indexes");
+                HttpResponseMessage response = await AzureSearchHelper.SendSearchRequestAsync(HttpClient, HttpMethod.Post, uri, json).ConfigureAwait(false);
+                response.EnsureSuccessStatusCode();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("  Error: {0}", ex.Message.ToString());
+            }
+        }
+
+        static int GetCurrentDocCount(SearchClient searchClient)
+        {
+            // Get the current doc count of the specified index
+            try
+            {
+                SearchOptions options = new SearchOptions()
+                {
+                    SearchMode = SearchMode.All,
+                    IncludeTotalCount = true
+                };
+
+                SearchResults<Dictionary<string, object>> response = searchClient.Search<Dictionary<string, object>>("*", options);
+                return Convert.ToInt32(response.TotalCount);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("  Error: {0}", ex.Message.ToString());
+            }
+
+            return -1;
+        }
+
+        static async Task ImportFromJSONAsync()
+        {
+            Console.WriteLine("\n  Upload index documents from saved JSON files");
+            // Take JSON file and import this as-is to updated index
+            Uri ServiceUri = new Uri("https://" + SearchServiceName + ".search.windows.net");
+            HttpClient HttpClient = new HttpClient();
+            HttpClient.DefaultRequestHeaders.Add("api-key", AdminKey);
+
+            try
+            {
+                foreach (string fileName in await AzureStorageHelper.GetDocumentsListAsync(StorageAccountConnectionString, BackupContainer, IndexName, ".json").ConfigureAwait(false))
+                {
+                    Console.WriteLine("  -Uploading documents from file {0}", fileName);
+                    string json = await AzureStorageHelper.DownloadAsync(StorageAccountConnectionString, BackupContainer, fileName).ConfigureAwait(false);
+                    Uri uri = new Uri(ServiceUri, "/indexes/" + IndexName + "/docs/index");
+                    HttpResponseMessage response = await AzureSearchHelper.SendSearchRequestAsync(HttpClient, HttpMethod.Post, uri, json).ConfigureAwait(false);
+                    response.EnsureSuccessStatusCode();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("  Error: {0}", ex.Message.ToString());
+            }
+        }
+    }
+}

--- a/update-index-schema-using-backup-restore-strategy-using-blobs/v11/AzureSearchSchemaUpdate/appsettings.json
+++ b/update-index-schema-using-backup-restore-strategy-using-blobs/v11/AzureSearchSchemaUpdate/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "SearchServiceName": "<<search service name>>",
+  "AdminKey": "<<admin key search - can be taken from keys tab under settings section in portal.>>",
+  "IndexName": "<<Name of the Index that needs to be updated.>>",
+  "StorageConnectionString": "<<Connection string of Azure storage account where the Schema and Index files are stored. can be taken from Access keys tab in security and networking section in portal.>>",
+  "BackupContainerName": "<<Backup container name for storage.>>"
+}


### PR DESCRIPTION
Rebuild the index : to update the schema in few scenarios as mentioned in the documentation : https://docs.microsoft.com/en-us/azure/search/search-howto-reindex. This tool will be useful.

Why It was needed for me?
Scenario: We had to update schema for one of the customer, where we had to make facetable for few fields, which requires an update to the existing schema. to do that we need to rebuild the index. 