### PR TITLE
Removed result count from header

### DIFF
--- a/create-first-app/v11/1-basic-search-page/FirstAzureSearchApp/Views/Home/Index.cshtml
+++ b/create-first-app/v11/1-basic-search-page/FirstAzureSearchApp/Views/Home/Index.cshtml
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="~/css/hotels.css" />
 </head>
 <body>
-    <h1 class="sampleTitle">@Model.resultList.TotalCount Results
+    <h1 class="sampleTitle">
         <img src="~/images/azure-logo.png" width="80" />
         Hotels Search
     </h1>


### PR DESCRIPTION
Adding the result count to the header without handling the model being null causes the page to error out when the app is first started. Removing the result count from the header (and leaving it only alongside the results within the Model != null block as outlined in the demo docs) resolves this issue.