### PR TITLE
Update export-data sample

### DIFF
--- a/export-data/ContinuousExporter.cs
+++ b/export-data/ContinuousExporter.cs
@@ -1,0 +1,117 @@
+﻿using Azure;
+using Azure.Search.Documents;
+using Azure.Search.Documents.Indexes;
+using Azure.Search.Documents.Indexes.Models;
+using Azure.Search.Documents.Models;
+using System.Text.Json;
+
+namespace export_data
+{
+    /// <summary>
+    /// Exports data continuously from an index, updating the documents when they have been exported
+    /// </summary>
+    public class ContinuousExporter : Exporter
+    {
+        private readonly SearchClient _searchClient;
+        private readonly SearchIndexClient _searchIndexClient;
+        private readonly string _exportFieldName;
+        private readonly int _pageSize;
+        private readonly string _exportPath;
+
+        public ContinuousExporter(SearchClient searchClient, SearchIndex index, SearchIndexClient searchIndexClient, string exportFieldName, int pageSize, string exportPath, IEnumerable<string> fieldsToInclude, ISet<string> fieldsToExclude) : base(index, fieldsToInclude, fieldsToExclude)
+        {
+            _searchClient = searchClient;
+            _searchIndexClient = searchIndexClient;
+            _exportFieldName = exportFieldName;
+            _pageSize = pageSize;
+            _exportPath = exportPath;
+        }
+
+        public override async Task ExportAsync()
+        {
+            await EnsureExportColumnExists();
+            SearchField keyField = Index.Fields.First(field => field.IsKey ?? false);
+
+            var exportUpdateOptions = new IndexDocumentsOptions { ThrowOnAnyError = true };
+
+            var options = new SearchOptions
+            {
+                Size = _pageSize,
+                // Set SessionId to target the same replica to retrieve consistent results
+                // To learn more, please visit https://learn.microsoft.com/azure/search/index-similarity-and-scoring#scoring-statistics-and-sticky-sessions
+                SessionId = Guid.NewGuid().ToString()
+            };
+            options.OrderBy.Add($"{_exportFieldName} asc");
+            AddSelect(options, _exportFieldName);
+
+            Console.WriteLine("Starting continuous export...");
+            using FileStream exportOutput = File.Open(_exportPath, FileMode.Append, FileAccess.Write, FileShare.Read);
+            bool firstDocumentExported = false;
+            do
+            {
+                SearchResults<SearchDocument> searchResults = await _searchClient.SearchAsync<SearchDocument>(searchText: string.Empty, options: options);
+                await foreach (Page<SearchResult<SearchDocument>> resultPage in searchResults.GetResultsAsync().AsPages())
+                {
+                    SearchResult<SearchDocument> firstResult = resultPage.Values.FirstOrDefault();
+                    if (firstResult == null)
+                    {
+                        firstDocumentExported = true;
+                        break;
+                    }
+
+
+                    if (firstResult.Document.TryGetValue(_exportFieldName, out object exportValue) &&
+                        exportValue is bool isExported &&
+                        isExported)
+                    {
+                        firstDocumentExported = true;
+                        break;
+                    }
+
+                    var exportedUpdates = new List<SearchDocument>();
+                    foreach (SearchResult<SearchDocument> searchResult in resultPage.Values)
+                    {
+                        searchResult.Document.Remove(_exportFieldName);
+                        JsonSerializer.Serialize(exportOutput, searchResult.Document);
+                        exportOutput.WriteByte((byte)'\n');
+
+                        exportedUpdates.Add(new SearchDocument
+                        {
+                            [keyField.Name] = searchResult.Document[keyField.Name],
+                            [_exportFieldName] = true
+                        });
+                    }
+
+                    if (exportedUpdates.Any())
+                    {
+                        // Delays in being able to search updates may cause already exported documents to be re-exported
+                        // To learn more, please see https://learn.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents#response
+                        await _searchClient.MergeOrUploadDocumentsAsync(exportedUpdates, exportUpdateOptions);
+                        Console.WriteLine($"Exported {exportedUpdates.Count} documents");
+                    }
+                }
+            }
+            while (!firstDocumentExported);
+
+            Console.WriteLine("Finished continuous export");
+        }
+
+        private async Task EnsureExportColumnExists()
+        {
+            SearchField exportField = Index.Fields.FirstOrDefault(field => field.Name == _exportFieldName);
+            if (exportField == null)
+            {
+                exportField = new SearchField(_exportFieldName, SearchFieldDataType.Boolean)
+                {
+                    IsSortable = true,
+                };
+                Index.Fields.Add(exportField);
+                await _searchIndexClient.CreateOrUpdateIndexAsync(Index);
+            }
+            else if (exportField.Type != SearchFieldDataType.Boolean)
+            {
+                throw new ArgumentException($"Export field {exportField.Name} has unexpected type {exportField.Type}, must be {SearchFieldDataType.Boolean}");
+            }
+        }
+    }
+}

--- a/export-data/Exporter.cs
+++ b/export-data/Exporter.cs
@@ -1,0 +1,69 @@
+﻿using Azure.Search.Documents;
+using Azure.Search.Documents.Indexes.Models;
+
+namespace export_data
+{
+    /// <summary>
+    /// Base class for exporting data from an index
+    /// </summary>
+    public abstract class Exporter
+    {
+        /// <summary>
+        /// What fields to include in the exported data
+        /// </summary>
+        protected IEnumerable<string> FieldsToInclude { get; }
+
+        /// <summary>
+        /// What fields to exclude from the exported data
+        /// </summary>
+        protected ISet<string> FieldsToExclude { get; }
+
+        protected SearchIndex Index { get; }
+
+        public Exporter(SearchIndex index, IEnumerable<string> fieldsToInclude, ISet<string> fieldsToExclude)
+        {
+            Index = index;
+            FieldsToInclude = fieldsToInclude;
+            FieldsToExclude = fieldsToExclude;
+        }
+
+        // Export data from the search index
+        public abstract Task ExportAsync();
+
+        // Update the $select clause in the query to pick the fields requested
+        // Learn more at https://learn.microsoft.com/azure/search/search-query-odata-select
+        protected void AddSelect(SearchOptions options, params string[] requiredFields)
+        {
+            if (FieldsToInclude?.Any() ?? false)
+            {
+                foreach (string field in FieldsToInclude)
+                {
+                    options.Select.Add(field);
+                }
+            }
+            else if (FieldsToExclude?.Any() ?? false)
+            {
+                foreach (string field in Index.Fields.Select(field => field.Name))
+                {
+                    if (!FieldsToExclude.Contains(field))
+                    {
+                        options.Select.Add(field);
+                    }
+                }
+            }
+
+            // If there are any required fields and we have specified either included or excluded fields,
+            // ensure the required fields are present
+            if (requiredFields.Length > 0 && options.Select.Any())
+            {
+                foreach (string requiredField in requiredFields)
+                {
+                    if (!options.Select.Contains(requiredField))
+                    {
+                        options.Select.Add(requiredField);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/export-data/README.md
+++ b/export-data/README.md
@@ -14,7 +14,7 @@ urlFragment: export-data
 
 ![Flask sample MIT license badge](https://img.shields.io/badge/license-MIT-green.svg)
 
-Export data from an Azure Cognitive Search service. This sample requires an index with a [sortable](https://learn.microsoft.com/azure/search/search-pagination-page-layout#ordering-with-orderby) and [filterable](https://learn.microsoft.com/azure/search/search-filters) field. This field is used to split up the data into smaller partitions that can be concurrently exported into JSON files. This .NET application runs on the command line.
+Export data from an Azure Cognitive Search service. This .NET application runs on the command line.
 
 ## Prerequisites
 
@@ -31,10 +31,33 @@ Export data from an Azure Cognitive Search service. This sample requires an inde
 
 1. Run the app locally [using Visual Studio](https://docs.microsoft.com/azure/azure-functions/functions-develop-local) or [dotnet run](https://learn.microsoft.com/dotnet/core/tools/dotnet-run)
 
-1. There are 3 commands in the app
+1. There are 4 commands in the app
     1. `get-bounds`
     1. `partition-index`
     1. `export-partitions`
+    1. `export-continuous`
+
+These commands support two different strategies for exporting data from the index
+
+1. Partitioned export. Documents in the index are split into smaller partitions that can be concurrently exported into JSON files.
+1. Continuous export. An additional field is added to your index to track export progress, and is continually updated as more documents are exported.
+
+These strategies have different tradeoffs. You should use partitioned export when:
+
+- You have a [sortable](https://learn.microsoft.com/azure/search/search-pagination-page-layout#ordering-with-orderby) and [filterable](https://learn.microsoft.com/azure/search/search-filters) field that can be used to partition the documents in the index.
+- You are not updating any documents in the index, or you are not updating the documents in the index you want to export.
+- You have a large number of documents. Partitioned export supports exporting more than 1000 documents concurrently. Export speed depends on [how your search service is provisioned](https://learn.microsoft.com/azure/search/search-capacity-planning).
+
+You should use continuous export when:
+
+- You do not have a [sortable](https://learn.microsoft.com/azure/search/search-pagination-page-layout#ordering-with-orderby) and [filterable](https://learn.microsoft.com/azure/search/search-filters) field. This field is required for partitioned export
+- You are actively updating the documents in the index you want to export
+- You have [storage space remaining on your search service](https://learn.microsoft.com/azure/search/search-limits-quotas-capacity#storage-limits), and are OK with the export process updating documents in the index. Continuous export adds an additional field to track export progress, which requires some storage be available.
+- Duplicate documents may be included in the exported data. If the search service has multiple replicas, a [best-effort attempt is made to use the same replica](https://learn.microsoft.com/azure/search/index-similarity-and-scoring#scoring-statistics-and-sticky-sessions) to ensure consistent export results. There may also [be a delay in updating already exported documents](https://learn.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents#response), so documents may be exported more than once.
+
+### Partitioned export commands
+
+#### get-bounds
 
 The `get-bounds` command is used to find the smallest and largest values of a sortable and filterable field in the index. This is used to determine how to split up the documents in the index into smaller partitions
 
@@ -65,6 +88,8 @@ Upper Bound 2022-11-06T12:14:21.0000000+00:00
 ```
 
 In this example, `date` is a [Edm.DateTimeOffset](https://learn.microsoft.com/rest/api/searchservice/supported-data-types) with the [sortable](https://learn.microsoft.com/azure/search/search-pagination-page-layout#ordering-with-orderby) and [filterable](https://learn.microsoft.com/azure/search/search-filters) attributes applied. The lowest possible value in the index for this field is 1969/12/31 and the highest possible value in the index for this field is 2011/11/06.
+
+#### partition-index
 
 The `partition-index` command is used to divide the index into smaller partitions.
 
@@ -113,13 +138,16 @@ In this case, `my-index-partitions.json` has a JSON description of the partition
       "documentCount": 62382,
       "filter": "date ge 1969-12-31T16:11:38.0000000+00:00 and date le 1976-08-09T12:41:58.3750000+00:00"
     },
-    ...
+    // more partitions in the same format as above
   ]
 ```
 
 The JSON file contains metadata about the index and the partitions it created, such as total document count and partition field name. The `partitions` field lists all the [filters](https://learn.microsoft.com/azure/search/search-filters) used to retrieve the partitions using [pagination](https://learn.microsoft.com/azure/search/search-pagination-page-layout#paging-results).
 
+#### export-partitions
+
 The `export-partitions` command is used to export the partitions created by `partition-index` into JSON files.
+
 ```
 Description:
   Exports data from a search index using a pre-generated partition file from partition-index
@@ -132,7 +160,7 @@ Options:
   --admin-key <admin-key> (REQUIRED)               Admin key to the search service to export data from
   --export-path <export-path>                      Directory to write JSON Lines partition files to. Every line in the partition
                                                    file contains a JSON object with the contents of the Search document. Format of
-                                                   file names is <index name>-<partition id>-documents.jsonl [default: .]
+                                                   file names is <index name>-<partition id>-documents.json [default: .]
   --concurrent-partitions <concurrent-partitions>  Number of partitions to concurrently export. Default is 2 [default: 2]
   --page-size <page-size>                          Page size to use when running export queries. Default is 1000 [default: 1000]
   --include-partition <include-partition>          List of partitions by index to include in the export. Example:
@@ -141,11 +169,16 @@ Options:
   --exclude-partition <exclude-partition>          List of partitions by index to exclude from the export. Example:
                                                    --exclude-partition 0 --exclude-partition 1 runs the export on every partition
                                                    except the first 2 []
+  --include-field <include-field>                  List of fields to include in the export. Example: --include-field field1
+                                                   --include-field field2. []
+  --exclude-field <exclude-field>                  List of fields to exclude in the export. Example: --exclude-field field1
+                                                   --exclude-field field2. []
   -?, -h, --help                                   Show help and usage information
 ```
 
 Sample usage:
-```
+
+```cmd
 dotnet run export-partitions --partition-path my-index-partitions.json --admin-key AAAAAAA --export-path C:\Users\MyAccount\output --concurrent-partitions 8
 Starting partition 2
 Starting partition 1
@@ -167,11 +200,61 @@ Ended partition 5
 
 The `export-partitions` command was run on partitions in the `my-index-partitions.json` file, which was output by the previous `partition-index` command. `--concurrent-partitions` was set to 8, so 8 partitions in this file were loaded into JSON files concurrently. This number can be changed to customize parallelization. Higher numbers increase load on the search service but complete the export more quickly. Lower numbers use less resources, but take a longer time to complete the export.
 
-1 JSON file per partition is output, with the file name formatted as `index-partition_index-documents.jsonl`. The output [JSONL files](https://jsonlines.org/) have 1 JSON object per line, corresponding to a single search document. All fields marked as [retrievable](https://learn.microsoft.com/azure/search/search-query-simple-examples) are exported.
-```
+1 JSON file per partition is output, with the file name formatted as `index-partition_index-documents.json`. The output [JSONL files](https://jsonlines.org/) have 1 JSON object per line, corresponding to a single search document. All fields marked as [retrievable](https://learn.microsoft.com/azure/search/search-query-simple-examples) are exported by default. Fields can be either explicitly included using `--include-field`, or explicitly excluded using `--exclude-field`.
+
+Example output in `index-0-documents.json`:
+
+```json
 {"id":"document-1", "text": "first document", "date":"1969-12-31T16:11:38Z"}
 {"id":"document-2","text": "second document", "date":"1969-12-31T17:05:39Z"}
 ...
+```
+
+### Continuous export commands
+
+#### export-continuous
+
+The `export-continuous` command starts finding documents that have not been exported and writes them into a JSON file
+
+```
+Description:
+  Exports data from a search service by adding a column to track which documents have been exported and continually updating it
+
+Usage:
+  export-data export-continuous [options]
+
+Options:
+  --endpoint <endpoint> (REQUIRED)         Endpoint of the search service to export data from. Example:
+                                           https://example.search.windows.net
+  --admin-key <admin-key> (REQUIRED)       Admin key to the search service to export data from
+  --index-name <index-name> (REQUIRED)     Name of the index to export data from
+  --export-field-name <export-field-name>  Name of the Edm.Boolean field the continuous export process will update to track which
+                                           documents have been exported. Default is 'exported' [default: exported]
+  --page-size <page-size>                  Page size to use when running export queries. Default is 1000 [default: 1000]
+  --export-path <export-path>              Path to write JSON Lines file to. Every line in the file contains a JSON object with the
+                                           contents of the Search document. Format of file is <index name>-documents.json []
+  --include-field <include-field>          List of fields to include in the export. Example: --include-field field1 --include-field
+                                           field2. []
+  --exclude-field <exclude-field>          List of fields to exclude in the export. Example: --exclude-field field1 --exclude-field
+                                           field2. []
+  -?, -h, --help                           Show help and usage information
+```
+
+Sample usage:
+
+```
+dotnet run export-continuous --endpoint https://example.search.windows.net --admin-key AAAA --index-name my-index   
+```
+
+1 JSON file is output, with the file name formatted as `my-index-documents.json`. The output [JSONL file](https://jsonlines.org/) has 1 JSON object per line, corresponding to a single search document. All fields marked as [retrievable](https://learn.microsoft.com/azure/search/search-query-simple-examples) are exported by default, except the field used to track if the document was exported or not. Fields can be either explicitly included using `--include-field`, or explicitly excluded using `--exclude-field`. If the export is cancelled, it is resumed where it left off.
+
+Duplicate documents may be included in the exported data. If the search service has multiple replicas, a [best-effort attempt is made to use the same replica](https://learn.microsoft.com/azure/search/index-similarity-and-scoring#scoring-statistics-and-sticky-sessions) to ensure consistent export results. There may also [be a delay in updating already exported documents](https://learn.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents#response), so documents may be exported more than once. Storage usage also increases as additional data is added to the index. If duplicate documents or storage limits are an issue, partitioned export is recommended.
+
+Example output in `my-index-documents.json`:
+
+```json
+{"id":"document-1", "text": "first document"}
+{"id":"document-2","text": "second document"}
 ```
 
 ## Next steps


### PR DESCRIPTION
* Add continuous export method for indexes without sortable and filterable fields
* This method causes increased storage usage, and may export duplicate documents
* Add explicitly included and excluded fields, without changing Retrievable status on index