### PR TITLE
Add semantic config param to multiple search services sample

### DIFF
--- a/multiple-search-services/Program.cs
+++ b/multiple-search-services/Program.cs
@@ -331,7 +331,7 @@ namespace MultipleSearchServices
             {
                 searchResults.Clear();
                 // Specify specific fields to search if given
-                var options = new SearchOptions { Size = pageSize, Skip = skip, IncludeTotalCount = count, QueryType = queryType, QueryLanguage = queryLanguage };
+                var options = new SearchOptions { Size = pageSize, Skip = skip, IncludeTotalCount = count, QueryType = queryType, QueryLanguage = queryLanguage, SemanticConfigurationName = service.SemanticConfigurationName };
 
                 if (!String.IsNullOrEmpty(searchFields))
                 {
@@ -525,6 +525,7 @@ namespace MultipleSearchServices
             public string AdminKey { get; set; }
             public string SearchEndpoint { get; set; }
             public string IndexName { get; set; }
+            public string SemanticConfigurationName { get; set; }
 
             public Uri SearchEndpointUri => new Uri(SearchEndpoint);
             public AzureKeyCredential SearchKeyCredential => new AzureKeyCredential(AdminKey);

--- a/multiple-search-services/appsettings.json
+++ b/multiple-search-services/appsettings.json
@@ -1,12 +1,16 @@
 {
+
   "service 1": {
     "adminKey": "Admin key for Search Service 1",
     "searchEndpoint": "https://[search-service-1-name].search.windows.net",
-    "indexName": "good-books"
+    "indexName": "good-books",
+    "semanticConfigurationName":  "name of semantic configuration, only required for semantic queries"
   },
   "service 2": {
     "adminKey": "Admin key for Search Service 2",
     "searchEndpoint": "https://[search-service-2-name].search.windows.net",
-    "indexName": "good-books"
+    "indexName": "good-books",
+    "semanticConfigurationName": "name of semantic configuration, only required for semantic queries"
   }
+
 }


### PR DESCRIPTION
* Update `appsettings.json` with a new parameter, `semanticConfigurationName`, to specify a config for semantic search