### PR TITLE
Update agentic retrieval quickstart SDK versions

### DIFF
--- a/quickstart-agentic-retrieval/AgenticRetrievalQuickstart.csproj
+++ b/quickstart-agentic-retrieval/AgenticRetrievalQuickstart.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.2" />
-    <PackageReference Include="Azure.Search.Documents" Version="11.8.0-beta.1" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Azure.Search.Documents" Version="12.1.0-beta.1" />
     <PackageReference Include="dotenv.net" Version="4.0.0" />
   </ItemGroup>
 

--- a/quickstart-agentic-retrieval/program.cs
+++ b/quickstart-agentic-retrieval/program.cs
@@ -177,7 +177,7 @@ namespace AzureSearch.Quickstart
             var baseClient = new KnowledgeBaseRetrievalClient(
                 endpoint: new Uri(searchEndpoint),
                 knowledgeBaseName: knowledgeBaseName,
-                tokenCredential: new DefaultAzureCredential()
+                credential: new DefaultAzureCredential()
             );
 
             string query = @"Why do suburban belts display larger December brightening than urban cores even though absolute light levels are higher downtown? Why is the Phoenix nighttime street grid is so sharply visible from space, whereas large stretches of the interstate between midwestern cities remain comparatively dim?";
@@ -291,7 +291,7 @@ namespace AzureSearch.Quickstart
             await indexClient.DeleteKnowledgeSourceAsync(knowledgeSourceName);
             Console.WriteLine($"Knowledge source '{knowledgeSourceName}' deleted successfully.");
 
-            await indexClient.DeleteIndexAsync(indexName);
+            await indexClient.DeleteIndexAsync(indexName, CancellationToken.None);
             Console.WriteLine($"Index '{indexName}' deleted successfully.");
         }
     }


### PR DESCRIPTION
## Summary
- Update agentic retrieval quickstart to Azure.Search.Documents 12.1.0-beta.1 and Azure.Identity 1.21.0.
- Adjust native SDK constructor/delete overload usage for the latest beta.

## Validation
- dotnet build AgenticRetrievalQuickstart.csproj
- dotnet run --project AgenticRetrievalQuickstart.csproj 